### PR TITLE
add reference to 0Harmony.dll

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,11 @@
             <Private>false</Private>
             <HintPath>$(MelonLoader)\MelonLoader.dll</HintPath>
         </Reference>
+        <Reference Include="0Harmony, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
+            <SpecificVersion>false</SpecificVersion>
+            <Private>false</Private>
+            <HintPath>$(MelonLoader)\0Harmony.dll</HintPath>
+        </Reference>
         <Reference Include="NAudio, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
             <SpecificVersion>false</SpecificVersion>
             <Private>false</Private>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current version of the mod is guaranteed to function on Muse Dash 2.2.0 (Apr
 ### How to build v3.0+
 
 #### Windows
-Run `setx MD_DIRECTORY "[Game path ending in \Muse Dash]"` in the command prompt.  
+Run `setx MD_DIRECTORY "Game path ending in \Muse Dash"` in the command prompt.  
 This provides a path for the project to find various DLL references from the game and MelonLoader.  
 Everything else should work out of the box.
 


### PR DESCRIPTION
the project threw errors if I don't reference to the dll :(
Also remove the square brackets in the readme to let newbies better understand how to use the command to set the environment (I guess it might be better😂) 